### PR TITLE
Added commandline parameter to filter device list by device name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,19 @@ npm link
 ```
 sim-boot
 ```
+
+### Filter list of device to boot
+
+```
+sim-boot -d "iPhone 8"
+```
+
+```
+sim-boot -d "iPhone8"
+```
+
+### Filter list of device to boot with partial device name
+
+```
+sim-boot -d "ipad"
+```

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ class BootSimulator {
   }
 
   async filterOnlyiOSSimulators() {
+    const device;
     list = await this.listSimulators();
     await _.map(list, (key, value) => {
       if (value.startsWith('iOS')) {
@@ -52,6 +53,11 @@ class BootSimulator {
         });
       }
     });
+    if(this.deviceInfo.length<1){
+      console.log("No device matches with provided device name");
+      device='';
+    }
+    else if(this.deviceInfo.length>1){
     const answer = await inquirer.prompt({
       type: 'list',
       name: 'Device',
@@ -60,11 +66,20 @@ class BootSimulator {
       choices: this.deviceInfo,
     });
 
-    const device = await _.split(answer.Device, '-');
-    const udid = await this.findUDIDOfSim(device[0], device[1]);
-    await exec(`xcrun simctl boot ${udid}`);
+    device = await _.split(answer.Device, '-');
+  }
+  else{
+    device= await _.split(this.deviceInfo[0],'-');
+
+  }
+
+    let udid = await getAllSimulator.findUDIDOfSim(device[0], device[1]);
+    if(udid){
+    console.log("Booting "+device[0]+" with "+device[1]);
+    await exec('xcrun simctl boot ' + udid);
     await exec('open /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app/');
 
+  }
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,13 @@ import { promisify } from 'util';
 const exec = promisify(require('child_process').exec);
 
 let list;
-let dev='';
+let deviceparam='';
+
+let simbootParams = require('optimist').argv;
+
+if(simbootParams.d){
+  deviceparam=simbootParams.d;
+}
 
 class BootSimulator {
   constructor() {

--- a/index.js
+++ b/index.js
@@ -7,28 +7,26 @@ import { promisify } from 'util';
 const exec = promisify(require('child_process').exec);
 
 let list;
-let deviceparam='';
-let simbootParams = require('optimist').argv;
+let deviceparam = '';
+const simbootParams = require('optimist').argv;
 
 class BootSimulator {
   constructor() {
     this.deviceInfo = [];
     this.iOSDevices = [];
     if(simbootParams.d){
-      deviceparam=simbootParams.d;
+      deviceparam = simbootParams.d;
     }
   }
 
   async listSimulators() {
-    let json;
     const { stdout } = await exec('xcrun simctl list --json devices');
     this.list = await stdout;
-    this.json = await JSON.parse(list);
-    return json.devices;
+    this.json = await JSON.parse(this.list);
+    return this.json.devices;
   }
 
   async findUDIDOfSim(name, version) {
-    let udid;
     await _.find(list, (key, value) => {
       if (value === version) {
         _.filter(key, obj => {
@@ -38,47 +36,44 @@ class BootSimulator {
         });
       }
     });
-    return udid;
+    return this.udid;
   }
 
   async filterOnlyiOSSimulators() {
-    const device;
+    let device;
     list = await this.listSimulators();
     await _.map(list, (key, value) => {
       if (value.startsWith('iOS')) {
         _.forEach(key, values => {
-
-          if(values.name.replace(/ /g,'').toUpperCase().includes(dev.replace(/ /g,'').toUpperCase()))
-          this.deviceInfo.push(`${values.name} - ${value}`);
+          if(values.name.replace(/ /g,'').toUpperCase().includes(deviceparam.replace(/ /g,'').toUpperCase()))
+            this.deviceInfo.push(`${values.name}-${value}`);
         });
       }
     });
     if(this.deviceInfo.length<1){
-      console.log("No device matches with provided device name");
-      device='';
+      console.log(`No device matches with provided device name`);
+      device = '';
     }
-    else if(this.deviceInfo.length>1){
-    const answer = await inquirer.prompt({
-      type: 'list',
-      name: 'Device',
-      message: 'Select Simulator 📱 to boot?',
-      pageSize: 15,
-      choices: this.deviceInfo,
-    });
+    else if(this.deviceInfo.length > 1){
+      const answer = await inquirer.prompt({
+        type: 'list',
+        name: 'Device',
+        message: 'Select Simulator 📱 to boot?',
+        pageSize: 15,
+        choices: this.deviceInfo,
+     });
+      device = await _.split(answer.Device, '-');
+    }
+    else{
+      device = await _.split(this.deviceInfo[0], '-');
+    }
 
-    device = await _.split(answer.Device, '-');
-  }
-  else{
-    device= await _.split(this.deviceInfo[0],'-');
-
-  }
-
-    let udid = await getAllSimulator.findUDIDOfSim(device[0], device[1]);
+    const udid = await getAllSimulator.findUDIDOfSim(device[0], device[1]);
     if(udid){
-    console.log("Booting "+device[0]+" with "+device[1]);
-    await exec('xcrun simctl boot ' + udid);
-    await exec('open -a Simulator --args -CurrentDeviceUDID '+udid);
-  }
+      console.log(`Booting ${device[0]} with ${device[1]}`);
+      await exec(`xcrun simctl boot  ${udid}`);
+      await exec(`open -a Simulator --args -CurrentDeviceUDID ${udid}`);
+    }
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -77,8 +77,7 @@ class BootSimulator {
     if(udid){
     console.log("Booting "+device[0]+" with "+device[1]);
     await exec('xcrun simctl boot ' + udid);
-    await exec('open /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app/');
-
+    await exec('open -a Simulator --args -CurrentDeviceUDID '+udid);
   }
   }
 }

--- a/index.js
+++ b/index.js
@@ -59,9 +59,12 @@ class BootSimulator {
       pageSize: 15,
       choices: this.deviceInfo,
     });
+
     const device = await _.split(answer.Device, '-');
     const udid = await this.findUDIDOfSim(device[0], device[1]);
     await exec(`xcrun simctl boot ${udid}`);
+    await exec('open /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app/');
+
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -8,17 +8,15 @@ const exec = promisify(require('child_process').exec);
 
 let list;
 let deviceparam='';
-
 let simbootParams = require('optimist').argv;
-
-if(simbootParams.d){
-  deviceparam=simbootParams.d;
-}
 
 class BootSimulator {
   constructor() {
     this.deviceInfo = [];
     this.iOSDevices = [];
+    if(simbootParams.d){
+      deviceparam=simbootParams.d;
+    }
   }
 
   async listSimulators() {

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ import { promisify } from 'util';
 const exec = promisify(require('child_process').exec);
 
 let list;
+let dev='';
 
 class BootSimulator {
   constructor() {
@@ -41,6 +42,8 @@ class BootSimulator {
     await _.map(list, (key, value) => {
       if (value.startsWith('iOS')) {
         _.forEach(key, values => {
+
+          if(values.name.replace(/ /g,'').toUpperCase().includes(dev.replace(/ /g,'').toUpperCase()))
           this.deviceInfo.push(`${values.name} - ${value}`);
         });
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3077,6 +3077,22 @@
         "mimic-fn": "1.2.0"
       }
     },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        }
+      }
+    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2952,8 +2952,7 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "exec-file-sync": "^2.0.2",
     "inquirer": "^6.0.0",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.10",
+    "optimist": "^0.6.1"
   }
 }


### PR DESCRIPTION
A command line parameter is added to filter the device list. Below are the examples. It can match with partial text and give result back.
sim-boot -d "iphone 8"
or 
sim-boot -d "iphone8"
or
sim-boot -d "ipad"